### PR TITLE
Feature/demo repository for cache

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.viewpagerdemo">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".MyApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/example/viewpagerdemo/data/result/Result.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/result/Result.kt
@@ -1,0 +1,24 @@
+package com.example.viewpagerdemo.data.result
+
+import java.lang.Exception
+
+/**
+ * A generic class that holds a value.
+ * @param <T>
+ */
+sealed class Result<out R> {
+
+    data class Success<out T>(val data: T?) : Result<T>()
+    data class Failure<out T>(val code: Int, val body: T?) : Result<T>() // TODO: define correct body
+    data class Error(val exception: Exception) : Result<Nothing>()
+    object Loading : Result<Nothing>()
+
+    override fun toString(): String {
+        return when (this) {
+            is Success<*> -> "Success[data=$data]"
+            is Failure -> "Failure[code=$code][body=$body]"
+            is Error -> "Error[exception=$exception]"
+            is Loading -> "Loading"
+        }
+    }
+}

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/GitHubDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/GitHubDataSource.kt
@@ -5,5 +5,5 @@ import com.example.viewpagerdemo.data.result.Result
 
 interface GitHubDataSource {
 
-    suspend fun getReposByUsername(): Result<GitHubRepo>
+    suspend fun getReposByUsername(): Result<List<GitHubRepo>>
 }

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/GitHubDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/GitHubDataSource.kt
@@ -6,4 +6,8 @@ import com.example.viewpagerdemo.data.result.Result
 interface GitHubDataSource {
 
     suspend fun getReposByUsername(): Result<List<GitHubRepo>>
+
+    suspend fun saveRepos(list: List<GitHubRepo>)
+
+    suspend fun deleteAllRepose()
 }

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/GitHubDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/GitHubDataSource.kt
@@ -1,0 +1,9 @@
+package com.example.viewpagerdemo.data.source
+
+import com.example.viewpagerdemo.data.model.GitHubRepo
+import com.example.viewpagerdemo.data.result.Result
+
+interface GitHubDataSource {
+
+    suspend fun getReposByUsername(): Result<GitHubRepo>
+}

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
@@ -20,4 +20,16 @@ class LocalDataSource(
         }
     }
 
+    override suspend fun saveRepos(list: List<GitHubRepo>) {
+        withContext(Dispatchers.IO) {
+            repoDao.insertAll(list)
+        }
+    }
+
+    override suspend fun deleteAllRepose() {
+        withContext(Dispatchers.IO) {
+            repoDao.deleteAll()
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
@@ -4,7 +4,9 @@ import com.example.viewpagerdemo.data.model.GitHubRepo
 import com.example.viewpagerdemo.data.result.Result
 import com.example.viewpagerdemo.data.source.GitHubDataSource
 
-class LocalDataSource : GitHubDataSource {
+class LocalDataSource(
+    private val repo: RepoDao
+): GitHubDataSource {
 
     override suspend fun getReposByUsername(): Result<GitHubRepo> {
         TODO("Not yet implemented")

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
@@ -1,0 +1,13 @@
+package com.example.viewpagerdemo.data.source.local
+
+import com.example.viewpagerdemo.data.model.GitHubRepo
+import com.example.viewpagerdemo.data.result.Result
+import com.example.viewpagerdemo.data.source.GitHubDataSource
+
+class LocalDataSource : GitHubDataSource {
+
+    override suspend fun getReposByUsername(): Result<GitHubRepo> {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/local/LocalDataSource.kt
@@ -3,13 +3,21 @@ package com.example.viewpagerdemo.data.source.local
 import com.example.viewpagerdemo.data.model.GitHubRepo
 import com.example.viewpagerdemo.data.result.Result
 import com.example.viewpagerdemo.data.source.GitHubDataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class LocalDataSource(
-    private val repo: RepoDao
+    private val repoDao: RepoDao
 ): GitHubDataSource {
 
-    override suspend fun getReposByUsername(): Result<GitHubRepo> {
-        TODO("Not yet implemented")
+    override suspend fun getReposByUsername(): Result<List<GitHubRepo>> {
+        return try {
+            withContext(Dispatchers.IO) {
+                Result.Success(repoDao.getAll())
+            }
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
     }
 
 }

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/local/RepoDao.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/local/RepoDao.kt
@@ -16,4 +16,7 @@ interface RepoDao {
 
     @Delete
     suspend fun delete(repo: GitHubRepo)
+
+    @Query("DELETE FROM github_repos")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
@@ -22,4 +22,12 @@ class RemoteDataSource(
         }
     }
 
+    override suspend fun saveRepos(list: List<GitHubRepo>) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteAllRepose() {
+        TODO("Not yet implemented")
+    }
+
 }

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
@@ -3,8 +3,11 @@ package com.example.viewpagerdemo.data.source.remote
 import com.example.viewpagerdemo.data.model.GitHubRepo
 import com.example.viewpagerdemo.data.result.Result
 import com.example.viewpagerdemo.data.source.GitHubDataSource
+import com.example.viewpagerdemo.data.source.remote.api.GitHubApi
 
-class RemoteDataSource : GitHubDataSource {
+class RemoteDataSource(
+    private val gitHubApi: GitHubApi
+) : GitHubDataSource {
 
     override suspend fun getReposByUsername(): Result<GitHubRepo> {
         TODO("Not yet implemented")

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
@@ -4,13 +4,22 @@ import com.example.viewpagerdemo.data.model.GitHubRepo
 import com.example.viewpagerdemo.data.result.Result
 import com.example.viewpagerdemo.data.source.GitHubDataSource
 import com.example.viewpagerdemo.data.source.remote.api.GitHubApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class RemoteDataSource(
     private val gitHubApi: GitHubApi
 ) : GitHubDataSource {
 
-    override suspend fun getReposByUsername(): Result<GitHubRepo> {
-        TODO("Not yet implemented")
+    override suspend fun getReposByUsername(): Result<List<GitHubRepo>> {
+        return withContext(Dispatchers.IO) {
+            val response = gitHubApi.getGithubRepos("mrky125", 1, 3)
+            if (response.isSuccessful) {
+                Result.Success(response.body())
+            } else {
+                Result.Failure(response.code(), null)
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/data/source/remote/RemoteDataSource.kt
@@ -1,0 +1,13 @@
+package com.example.viewpagerdemo.data.source.remote
+
+import com.example.viewpagerdemo.data.model.GitHubRepo
+import com.example.viewpagerdemo.data.result.Result
+import com.example.viewpagerdemo.data.source.GitHubDataSource
+
+class RemoteDataSource : GitHubDataSource {
+
+    override suspend fun getReposByUsername(): Result<GitHubRepo> {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/java/com/example/viewpagerdemo/di/GitHubContainer.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/di/GitHubContainer.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import androidx.room.Room
 import com.example.viewpagerdemo.data.source.remote.RetrofitBuilder
 import com.example.viewpagerdemo.data.source.local.GitHubDatabase
+import com.example.viewpagerdemo.data.source.local.LocalDataSource
+import com.example.viewpagerdemo.data.source.remote.RemoteDataSource
+import com.example.viewpagerdemo.repository.GitHubRepositoryImpl
 
 /**
  * Container to inject dependencies manually
@@ -12,12 +15,18 @@ class GitHubContainer(
     context: Context
 ) {
 
-    val githubApi by lazy {
+    private val githubApi by lazy {
         RetrofitBuilder.createGithubApi()
     }
 
-    val database by lazy {
+    private val database by lazy {
         createDatabase(context)
+    }
+
+    val githubRepository by lazy {
+        val remoteDataSource = RemoteDataSource(githubApi)
+        val localDataSource = LocalDataSource(database.repoDao())
+        GitHubRepositoryImpl(remoteDataSource, localDataSource)
     }
 
     private fun createDatabase(context: Context): GitHubDatabase {

--- a/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepository.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepository.kt
@@ -1,0 +1,9 @@
+package com.example.viewpagerdemo.repository
+
+import com.example.viewpagerdemo.data.model.GitHubRepo
+import com.example.viewpagerdemo.data.result.Result
+
+interface GitHubRepository {
+
+    suspend fun getReposByUsername(): Result<GitHubRepo>
+}

--- a/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepository.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepository.kt
@@ -5,5 +5,5 @@ import com.example.viewpagerdemo.data.result.Result
 
 interface GitHubRepository {
 
-    suspend fun getReposByUsername(): Result<GitHubRepo>
+    suspend fun getReposByUsername(): Result<List<GitHubRepo>>
 }

--- a/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
@@ -9,8 +9,8 @@ class GitHubRepositoryImpl(
     private val localDataSource: GitHubDataSource
 ) : GitHubRepository {
 
-    override suspend fun getReposByUsername(): Result<GitHubRepo> {
-        TODO("Not yet implemented")
+    override suspend fun getReposByUsername(): Result<List<GitHubRepo>> {
+        return remoteDataSource.getReposByUsername()
     }
 
 }

--- a/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
@@ -10,7 +10,22 @@ class GitHubRepositoryImpl(
 ) : GitHubRepository {
 
     override suspend fun getReposByUsername(): Result<List<GitHubRepo>> {
+        val forceUpdate = false // fake value
+        if (forceUpdate) {
+            // Never pass here until implement updateLocalRepos()
+            updateLocalRepos()
+        }
+
         return remoteDataSource.getReposByUsername()
+    }
+
+    private suspend fun updateLocalRepos() {
+        val remoteRepos = remoteDataSource.getReposByUsername()
+        if (remoteRepos is Result.Success) {
+            // TODO: delete local and insert all
+        } else {
+            throw Exception("failed to fetch")
+        }
     }
 
 }

--- a/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
@@ -2,8 +2,12 @@ package com.example.viewpagerdemo.repository
 
 import com.example.viewpagerdemo.data.model.GitHubRepo
 import com.example.viewpagerdemo.data.result.Result
+import com.example.viewpagerdemo.data.source.GitHubDataSource
 
-class GitHubRepositoryImpl : GitHubRepository {
+class GitHubRepositoryImpl(
+    private val remoteDataSource: GitHubDataSource,
+    private val localDataSource: GitHubDataSource
+) : GitHubRepository {
 
     override suspend fun getReposByUsername(): Result<GitHubRepo> {
         TODO("Not yet implemented")

--- a/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.example.viewpagerdemo.repository
+
+import com.example.viewpagerdemo.data.model.GitHubRepo
+import com.example.viewpagerdemo.data.result.Result
+
+class GitHubRepositoryImpl : GitHubRepository {
+
+    override suspend fun getReposByUsername(): Result<GitHubRepo> {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/repository/GitHubRepositoryImpl.kt
@@ -20,7 +20,7 @@ class GitHubRepositoryImpl(
             }
         }
         Log.d("repository", "succeeded to update local db")
-        return remoteDataSource.getReposByUsername()
+        return localDataSource.getReposByUsername()
     }
 
     private suspend fun updateLocalRepos() {

--- a/app/src/main/java/com/example/viewpagerdemo/ui/ScreenSlidePageActivity.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/ui/ScreenSlidePageActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.widget.ViewPager2
+import com.example.viewpagerdemo.MyApplication
 import com.example.viewpagerdemo.R
 import com.example.viewpagerdemo.viewmodel.factory.SlideSharedViewModelFactory
 import kotlinx.android.synthetic.main.activity_screen_slide.*
@@ -26,7 +27,7 @@ class ScreenSlidePagerActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_screen_slide)
 
-        viewModelFactory = SlideSharedViewModelFactory()
+        setupViewModelFactory()
 
         // Instantiate a ViewPager2 and a PagerAdapter.
         viewPager = findViewById(R.id.pager)
@@ -45,6 +46,11 @@ class ScreenSlidePagerActivity : FragmentActivity() {
 
         // For testing, access an instance of a page number.
         Log.d(TAG, "${page_number.accessibilityClassName}")
+    }
+
+    private fun setupViewModelFactory() {
+        val repository = MyApplication.gitHubContainer.githubRepository
+        viewModelFactory = SlideSharedViewModelFactory(repository)
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/example/viewpagerdemo/ui/ScreenSlidePageFragment.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/ui/ScreenSlidePageFragment.kt
@@ -21,7 +21,7 @@ class ScreenSlidePageFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val activity = requireActivity() as ScreenSlidePagerActivity
-        val viewModel =
+        viewModel =
             ViewModelProvider(activity, activity.viewModelFactory).get(SlideSharedViewModel::class.java)
         Log.d("viewModel", "$viewModel")
         return inflater.inflate(R.layout.fragment_screen_slide_page, container, false)

--- a/app/src/main/java/com/example/viewpagerdemo/ui/ScreenSlidePageFragment.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/ui/ScreenSlidePageFragment.kt
@@ -32,6 +32,7 @@ class ScreenSlidePageFragment : Fragment() {
         arguments?.let {
             page_number.text = it.getInt(ARGS_PAGER_POSITION).toString()
         }
+        viewModel.initRepoList()
     }
 
     companion object {

--- a/app/src/main/java/com/example/viewpagerdemo/viewmodel/SlideSharedViewModel.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/viewmodel/SlideSharedViewModel.kt
@@ -1,10 +1,24 @@
 package com.example.viewpagerdemo.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.viewpagerdemo.repository.GitHubRepository
+import kotlinx.coroutines.launch
 
-class SlideSharedViewModel : ViewModel() {
+class SlideSharedViewModel(
+    private val gitHubRepository: GitHubRepository
+) : ViewModel() {
 
     // expose shared live data
 
     // expose function to update shared live data
+
+
+    fun initRepoList() {
+        viewModelScope.launch {
+            val result = gitHubRepository.getReposByUsername()
+            Log.d("viewModel", "result: $result")
+        }
+    }
 }

--- a/app/src/main/java/com/example/viewpagerdemo/viewmodel/SlideSharedViewModel.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/viewmodel/SlideSharedViewModel.kt
@@ -3,8 +3,10 @@ package com.example.viewpagerdemo.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.viewpagerdemo.data.result.Result
 import com.example.viewpagerdemo.repository.GitHubRepository
 import kotlinx.coroutines.launch
+import okhttp3.internal.wait
 
 class SlideSharedViewModel(
     private val gitHubRepository: GitHubRepository
@@ -19,6 +21,14 @@ class SlideSharedViewModel(
         viewModelScope.launch {
             val result = gitHubRepository.getReposByUsername()
             Log.d("viewModel", "result: $result")
+            when (result) {
+                is Result.Success -> {
+                    result.data!!.forEach {
+                        Log.d("viewModel", "item id: ${it.id}, name: ${it.repoName}, url: ${it.url}")
+                    }
+                }
+                else -> Log.e("viewModel", "failed")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/viewpagerdemo/viewmodel/factory/SlideSharedViewModelFactory.kt
+++ b/app/src/main/java/com/example/viewpagerdemo/viewmodel/factory/SlideSharedViewModelFactory.kt
@@ -2,16 +2,19 @@ package com.example.viewpagerdemo.viewmodel.factory
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.example.viewpagerdemo.repository.GitHubRepository
 import com.example.viewpagerdemo.viewmodel.SlideSharedViewModel
 
-class SlideSharedViewModelFactory : ViewModelProvider.Factory {
+class SlideSharedViewModelFactory(
+    private val gitHubRepository: GitHubRepository
+) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         return with(modelClass) {
             when {
                 isAssignableFrom(SlideSharedViewModel::class.java) -> {
-                    SlideSharedViewModel()
+                    SlideSharedViewModel(gitHubRepository)
                 }
                 else ->
                     throw IllegalStateException("Unknown ViewModel class: ${modelClass.name}")


### PR DESCRIPTION
# 概要
Repository にてキャッシュを返却するようにした。デモ。
ViewModel に返すデータはローカルDBから取得している。
強制フェッチを指示されると、Repository はローカルDBのレコードを全削除してリモートからフェッチする。フェッチで取得したデータはローカルDBに保存する。

# 予定
一通り動くことが確認できたので、Paging にリモートからのフェッチとローカルキャッシュを組み込んでみる。

# 課題
- 命名が全体的に良く無い
  - GitHubと付けたのが失敗
  - View側もViewPagerするためだけの命名
- Daoのクエリを整理する。（ソートやbyNameでの取得など）
- Result型のラップが成功を前提の実装になってしまっている